### PR TITLE
Issue 12: Added inefficient collision detection

### DIFF
--- a/template/core/game/changer.py
+++ b/template/core/game/changer.py
@@ -19,6 +19,8 @@ class GameChanger:
           self.quit_game()
 
       active_display.update_event(event)
+    active_display.update_self()
+    active_display.check_collisions()
 
   def quit_game(self):
     pygame.quit()

--- a/template/packages/collision/collision.py
+++ b/template/packages/collision/collision.py
@@ -2,8 +2,10 @@ import pygame
 from pygame.locals import *
 
 class CollisionBox:
-  def __init__(self, game_object, scale=False):
-    self.adjust(game_object, scale)
+  def __init__(self, game_object, dim=False):
+    if not dim:
+      self.dim = (0, 0)
+    self.adjust(game_object)
 
   def is_clicked(self, offset=False):
     if not offset:
@@ -19,7 +21,9 @@ class CollisionBox:
 
   def adjust(self, game_object, scale=False):
     if not scale:
-      scale = (0, 0)
+      scale = self.dim
+    else:
+      self.dim = scale
 
     w = int(game_object.image.get_width() * scale[0])
     h = int(game_object.image.get_height() * scale[1])
@@ -37,5 +41,6 @@ class CollisionBox:
 
     self.box = box
 
-
+  def set_dim(self, dim_x, dim_y):
+    self.dim = (dim_x, dim_y)
 

--- a/template/packages/display/base.py
+++ b/template/packages/display/base.py
@@ -46,6 +46,10 @@ class BaseDisplay(ABC):
     pass
 
   @abstractmethod
+  def update_self(self):
+    pass
+
+  @abstractmethod
   def update_event(self):
     pass
 

--- a/template/packages/display/game.py
+++ b/template/packages/display/game.py
@@ -42,6 +42,10 @@ class GameDisplay(BaseDisplay):
       layer.set_dt(self.dt)
       layer.update()
 
+  def update_self(self):
+    for layer in self.layers:
+      layer.update_self()
+
   def update_event(self, event):
     for layer in self.layers:
       layer.update_event(event)
@@ -53,3 +57,17 @@ class GameDisplay(BaseDisplay):
       layer.draw()
       self.surface.blit(layer.surface, (0,0))
     self.canvas.surface.blit(self.surface, (0,0))
+
+  def check_collisions(self):
+    for layer_curr in self.layers:
+      for k, item1 in layer_curr.items.items():
+        for layer_othr in self.layers:
+          for k, item2 in layer_othr.items.items():
+            if item1 is item2:
+              continue
+            if item1.box.has_collided(item2.box):
+              item1.collisions[item2.name] = item2
+              item2.collisions[item1.name] = item1
+            else:
+              item1.collisions.pop(item2.name, None)
+              item2.collisions.pop(item1.name, None)

--- a/template/packages/display/layer.py
+++ b/template/packages/display/layer.py
@@ -7,7 +7,7 @@ from packages.display.base import BaseDisplay
 from packages.image.image import Image
 from packages.objects.game import GameObject
 from packages.objects.text import TextObject
-from packages.value.constants import ORANGE
+from packages.value.constants import BLUE
 from packages.value.constants import GRID_DIM
 from packages.value.constants import LAYER_DISPLAY_KEY
 
@@ -44,7 +44,8 @@ class Layer(BaseDisplay):
 
   def draw(self):
     for key, item in self.items.items():
-      # pygame.draw.rect(self.surface, ORANGE, item.box.box)
+      item.box.adjust(item)
+      pygame.draw.rect(self.surface, BLUE, item.box.box)
       item.draw()
     for text_item in self.text_items:
       # pygame.draw.rect(self.surface, ORANGE, text_item.box.box)
@@ -67,6 +68,9 @@ class Layer(BaseDisplay):
 
   def set_canvas_to(self, canvas):
     self.canvas = canvas
+
+  def update_self(self):
+    pass
 
   def _set_as_layer_for(self, item):
     item.canvas = self.surface
@@ -96,6 +100,9 @@ class LayerItem(GameObject):
 
   def change_image(self, image_key):
     self.image = Image.resize(Image.get(image_key), (self.image.get_width(), self.image.get_height()))
+
+  def has_collided(self):
+    return len(self.collisions)> 0
 
 class TextItem(TextObject):
   def __init__(self, text, position=False):

--- a/template/packages/display/main.py
+++ b/template/packages/display/main.py
@@ -19,6 +19,9 @@ class MainDisplay(BaseDisplay):
   def update(self):
     pass
 
+  def update_self(self):
+    pass
+
   def update_event(self, event):
     pass
 

--- a/template/packages/objects/game.py
+++ b/template/packages/objects/game.py
@@ -15,10 +15,8 @@ class GameObject(ABC):
     self.image = Image.resize(image, new_dimensions)
     self.position = position
     self.is_active = True
+    self.collisions = {}
     self.box = CollisionBox(self)
-
-  def resize_collision_box(self, scale):
-    self.box = CollisionBox(self, scale)
 
   def change_name(self, name):
     self.name = name
@@ -37,4 +35,8 @@ class GameObject(ABC):
 
   @abstractmethod
   def draw(self):
+    pass
+
+  @abstractmethod
+  def has_collided(self):
     pass


### PR DESCRIPTION
- Displays (including layers) now have a way to update themselves
- Displays now have a way to check collisions between layer items across all their layers. 
- Collision boxes now actually move with their item
- Items now save collision data in a `collisions` property
- Items now have a method to perform a simple check to see if they have collided with anything or not